### PR TITLE
Differentiate by account type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,14 @@ Provider Configuration
 
 Firstly, to use the provider you will need to create a user within Snowflake that can execute the resource requests made by Terraform
 
+Account type defaults to standard, but can be either standard or enterprise.
+
 ```sh
 $ export SF_USER
 $ export SF_PASSWORD
 $ export SF_REGION
 $ export SF_ACCOUNT
+$ export SF_ACCOUNT_TYPE
 ```
 
 ### Snowflake Warehouse Management

--- a/snowflake/provider.go
+++ b/snowflake/provider.go
@@ -15,9 +15,13 @@ import (
 // DefaultSnowFlakeRegion mentions SnowFlake Account Region
 const DefaultSnowFlakeRegion = "us-west-2"
 
+// DefaultAccountType is the account type for the Snowflake Account ("standard" or "enterprise")
+const DefaultAccountType = "standard"
+
 type providerConfiguration struct {
 	DB            *sql.DB
 	ServerVersion *version.Version
+	AccountType   string
 }
 
 // Provider blah foo bar
@@ -62,6 +66,12 @@ func Provider() terraform.ResourceProvider {
 				Description: "Snowflake region that is configured with account",
 				DefaultFunc: schema.EnvDefaultFunc("SF_REGION", DefaultSnowFlakeRegion),
 			},
+			"account_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Snowflake account type (standard or enterprise)",
+				DefaultFunc: schema.EnvDefaultFunc("SF_ACCOUNT_TYPE", DefaultAccountType),
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -81,6 +91,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	var password = d.Get("password").(string)
 	var account = d.Get("account").(string)
 	var region = d.Get("region").(string)
+	var accountType = d.Get("account_type").(string)
 
 	// database/sql is the thread-safe by default, so we can
 	// safely re-use the same handle between multiple parallel
@@ -100,6 +111,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return &providerConfiguration{
 		DB:            db,
 		ServerVersion: ver,
+		AccountType:   accountType,
 	}, nil
 }
 

--- a/snowflake/resource_warehouse.go
+++ b/snowflake/resource_warehouse.go
@@ -92,7 +92,7 @@ func resourceWarehouse() *schema.Resource {
 				Optional:    true,
 				Default:     1,
 				ForceNew:    false,
-				Description: "Specifies the maximum number of server clusters for the warehouse",
+				Description: "Specifies the maximum number of server clusters for a multi-cluster warehouse",
 			},
 			whMinClusterCount: {
 				Type:        schema.TypeInt,
@@ -145,7 +145,7 @@ func createWarehouse(d *schema.ResourceData, meta interface{}) error {
 			fmt.Fprintf(b, " %s=%v ", attr, d.Get(attr))
 		}
 	}
-	for _, attr := range []string{whMaxClusterCount, whMinClusterCount, whAutoSuspend, whAutoResume, whInitiallySuspended} {
+	for _, attr := range []string{whAutoSuspend, whAutoResume, whInitiallySuspended} {
 		fmt.Fprintf(b, " %s=%v ", attr, d.Get(attr))
 	}
 	// Wrap string values in quotes
@@ -203,8 +203,7 @@ func readWarehouse(d *schema.ResourceData, meta interface{}) error {
 
 	var err error
 
-	// figure out a better way to do this, we should be able to construct a group of parameters that are enterprise vs non-enterprise
-	if d.Get(whMulticlusterEnabled) == true {
+	if meta.(*providerConfiguration).AccountType == "enterprise" {
 		err = db.QueryRow(stmtSQL).Scan(
 			&name, &state, &instanceType, &size, &minClusterCount, &maxClusterCount, &startedClusters, &scalingPolicy, &running, &queued,
 			&isDefault, &isCurrent, &autoSuspend, &autoResume, &available, &provisioning, &quiescing, &other,
@@ -249,7 +248,7 @@ func readWarehouse(d *schema.ResourceData, meta interface{}) error {
 	d.Set("failed", failed)
 	d.Set("suspended", suspended)
 	d.Set("id", uuid)
-	if d.Get(whMulticlusterEnabled) == true {
+	if meta.(*providerConfiguration).AccountType == "enterprise" {
 		d.Set("min_cluster_count", minClusterCount)
 		d.Set("max_cluster_count", maxClusterCount)
 		d.Set("started_clusters", startedClusters)


### PR DESCRIPTION
So it looks like Snowflake returns different things from warehouse queries in addition to offering different features. This PR exposes a SF_ACCOUNT_TYPE variable (defaulted to "standard", can also be "enterprise") to account for this.