### PR TITLE
Multicluster min/max args duplicated

### DIFF
--- a/snowflake/resource_warehouse.go
+++ b/snowflake/resource_warehouse.go
@@ -145,7 +145,7 @@ func createWarehouse(d *schema.ResourceData, meta interface{}) error {
 			fmt.Fprintf(b, " %s=%v ", attr, d.Get(attr))
 		}
 	}
-	for _, attr := range []string{whMaxClusterCount, whMinClusterCount, whAutoSuspend, whAutoResume, whInitiallySuspended} {
+	for _, attr := range []string{whAutoSuspend, whAutoResume, whInitiallySuspended} {
 		fmt.Fprintf(b, " %s=%v ", attr, d.Get(attr))
 	}
 	// Wrap string values in quotes


### PR DESCRIPTION
1da5f96 made a change to only show
min/max cluster count if multicluster is enabled but left it in the line
below

https://github.com/ShopRunner/terraform-provider-snowflake/commit/1da5f96ccbe42ac926a508cf33a77f601e8ed03c#diff-11c795e53c5b78c1528af37ed683acf9R142

This PR cleans that up by removing the duplicated parameters

Don't know your process so let me know if I missed anything. Tried to do the basics: Tests pass. Formatting pass. Err check catches some unchecked errs that are unrelated to this PR.